### PR TITLE
Tony/630 try another webid

### DIFF
--- a/lib/solid_auth_client.dart
+++ b/lib/solid_auth_client.dart
@@ -56,6 +56,47 @@ PlatformInfo currPlatform = PlatformInfo();
 
 AuthManager authManager = AuthManager();
 
+/// Thrown by [authenticate] when the in-flight OAuth flow is aborted via
+/// [cancelAuthenticate]. Lets callers distinguish a deliberate user (or
+/// programmatic) cancellation from a genuine network/server failure so they
+/// can suppress error UI accordingly.
+
+class AuthCancelledException implements Exception {
+  final String message;
+
+  const AuthCancelledException([
+    this.message = 'Authentication was cancelled',
+  ]);
+
+  @override
+  String toString() => 'AuthCancelledException: $message';
+}
+
+/// Reference to the desktop [oidc_mobile.Authenticator] currently waiting on
+/// the OAuth callback. Tracked here so [cancelAuthenticate] can tear it down
+/// from outside the awaiting code path without having to thread the handle
+/// through the call site.
+
+oidc_mobile.Authenticator? _pendingAuthenticator;
+
+/// Returns true while a desktop [authenticate] call is awaiting the OAuth
+/// browser redirect. Useful for UI code that wants to gate retry buttons
+/// while a previous attempt is still pending.
+
+bool isAuthenticatePending() => _pendingAuthenticator != null;
+
+/// Aborts any in-flight desktop [authenticate] call. The awaited future
+/// throws an [AuthCancelledException], the local OAuth callback HTTP server
+/// is closed when no other flow needs it, and the cached authenticator
+/// reference is cleared.
+
+Future<void> cancelAuthenticate() async {
+  final pending = _pendingAuthenticator;
+  if (pending == null) return;
+  _pendingAuthenticator = null;
+  await pending.cancel();
+}
+
 /// Dynamically register the user in the POD server
 Future<String> clientDynamicReg(
   String regEndpoint,
@@ -260,8 +301,32 @@ Future<Map> authenticate(
           'Authentication process completed. You can now close this window!',
     );
 
-    /// starts the authentication + authorisation process
-    authResponse = await authenticator.authorize();
+    // Publish the in-flight authenticator so [cancelAuthenticate] can tear
+    // it down from outside this call. Any previously pending authenticator
+    // is cancelled first to free the shared local OAuth callback server.
+    final previous = _pendingAuthenticator;
+    if (previous != null) {
+      try {
+        await previous.cancel();
+      } on Object {
+        // Best-effort cleanup; ignore failures from the prior flow.
+      }
+    }
+    _pendingAuthenticator = authenticator;
+
+    try {
+      /// starts the authentication + authorisation process
+      authResponse = await authenticator.authorize();
+    } on Exception catch (e) {
+      if (e.toString().contains('Flow was cancelled')) {
+        throw const AuthCancelledException();
+      }
+      rethrow;
+    } finally {
+      if (identical(_pendingAuthenticator, authenticator)) {
+        _pendingAuthenticator = null;
+      }
+    }
 
     /// close the webview when finished
     /// closing web view function does not work in Windows applications

--- a/lib/solid_auth_client.dart
+++ b/lib/solid_auth_client.dart
@@ -317,8 +317,8 @@ Future<Map> authenticate(
     try {
       /// starts the authentication + authorisation process
       authResponse = await authenticator.authorize();
-    } on Exception catch (e) {
-      if (e.toString().contains('Flow was cancelled')) {
+    } on Exception {
+      if (!identical(_pendingAuthenticator, authenticator)) {
         throw const AuthCancelledException();
       }
       rethrow;

--- a/lib/src/openid/openid_client_io.dart
+++ b/lib/src/openid/openid_client_io.dart
@@ -134,16 +134,37 @@ class Authenticator {
 
   /// Cancels the authentication flow.
   ///
-  /// This method will stop the local http server and complete the [authorize]
-  /// method with an error.
+  /// Errors the [authorize] future for this authenticator's state with a
+  /// `Flow was cancelled` [Exception] and tears down the shared local http
+  /// server when there are no other in-flight authentications waiting on it.
   ///
-  /// This method should be called when the user cancels the authentication flow
-  /// in the browser.
+  /// Idempotent: safe to call multiple times, and a no-op when the flow has
+  /// already completed or has no registered state. This matters on desktop
+  /// where there is no reliable signal that the user has closed the external
+  /// browser window, so cancellation may be requested speculatively.
   Future<void> cancel() async {
     final state = flow.authenticationUri.queryParameters['state'];
-    _requestsByState[state!]?.completeError(Exception('Flow was cancelled'));
-    final server = await _requestServers.remove(port);
-    await server?.close();
+    if (state == null) return;
+
+    final completer = _requestsByState.remove(state);
+    if (completer != null && !completer.isCompleted) {
+      completer.completeError(Exception('Flow was cancelled'));
+    }
+
+    // Only stop the local OAuth callback server when no other states are
+    // still waiting for a redirect. Closing it whilst another authenticator
+    // is still in flight would strand that flow on a dead socket.
+    if (_requestsByState.isEmpty) {
+      final serverFuture = _requestServers.remove(port);
+      if (serverFuture != null) {
+        try {
+          final server = await serverFuture;
+          await server.close(force: true);
+        } on Object {
+          // Server may already be closed or never finished binding — ignore.
+        }
+      }
+    }
   }
 
   static final Map<int, Future<HttpServer>> _requestServers = {};

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
 dev_dependencies:
   flutter_lints: ^5.0.0
   jwt_decoder: ^2.0.1
-  # Keep dependency checker quiet.
+  # Keep the dependency checker quiet.
   solid_auth_example:
     path: example
 


### PR DESCRIPTION
## Pull Request Details

### Description
<!--- Describe the problem this PR solves -->
<!--- Describe what you have changed -->
<!--- Describe why this change is required -->
Added cancelAuthenticate() and AuthCancelledException so callers can abort a stuck desktop OAuth flow when the user closes the browser window before completing login.

### Related Issues
<!--- If it fixes an open issue(s), please link to the issue here. -->
anusii/solidpod#630

### Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How To Test?
<!--- Describe the tests that a reviewer can undertake to verify your changes. -->
Run RioPod using `tony/630_try_another_webid` branch to test, and follow the steps below.

- Started RioPod and clicked on "Try another WebID"
- Close the web browser. The app were still showing the loading animation.
- Then clicked on the Cancel button, and clicked on "Try another WebID" again.
- The web browser popped up again, and see messages in CLI.

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] Screenshots included in linked issue #
- [x] Changes adhere to the [style and coding guidelines](https://survivor.togaware.com/gnulinux/flutter-style.html)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] Any dependent changes have been merged and published in downstream modules
- [x] The update contains no confidential information
- [x] The update has no duplicated content
- [x] No lint check errors are related to these changes (`make prep` or `flutter analyze lib`)
- [ ] Integration test `dart test` output or screenshot included in issue #
- [x] I tested the PR on these devices:
  - [ ] Android
  - [ ] iOS
  - [ ] Linux
  - [x] MacOS
  - [x] Windows
  - [ ] Web
- [x] I have identified reviewers
- [ ] The PR has been approved by reviewers

### Finalising
<!--- Once PR discussion is complete and reviewers have approved. -->

- [ ] Merge dev into the this branch
- [ ] Resolve any conflicts
- [ ] Add a one line summary into the CHANGELOG.md
- [ ] Push to the git repository and review
- [ ] Merge the PR into dev
